### PR TITLE
Remove unused updateTimer

### DIFF
--- a/HW Monitor/module.php
+++ b/HW Monitor/module.php
@@ -1,7 +1,6 @@
 <?php
 class HWMonitor extends IPSModule
 {
-    private $updateTimer;
 
     protected function searchValueForId($jsonArray, $searchId, &$foundValues)
     {


### PR DESCRIPTION
## Summary
- remove unused `$updateTimer` property from the module

## Testing
- `php -l 'HW Monitor/module.php'` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ea507c8548326ae2b2cc43fbf6d52