### PR TITLE
Handle JSON decoding failure

### DIFF
--- a/HW Monitor/README.md
+++ b/HW Monitor/README.md
@@ -78,7 +78,8 @@ Anzeige der gewünschten Variabeln oder Grafiken in der Visualisierung.
 ### 7. PHP-Befehlsreferenz
 
 `boolean HW_Update(integer $InstanzID);`
-Aktualisierung der Daten.
+Aktualisierung der Daten. Gibt bei erfolgreichem Einlesen der JSON-Daten `true`
+zurück, andernfalls `false`.
 
 Beispiel:
 `HW_Update(12345);`

--- a/HW Monitor/module.php
+++ b/HW Monitor/module.php
@@ -74,7 +74,9 @@ class HWMonitor extends IPSModule
             $this->SendDebug("Konfiguration", "IP-Adresse ist nicht konfiguriert", 0);
             $this->LogMessage("IP-Adresse ist nicht konfiguriert", KL_ERROR);
         } else {
-            $this->Update();
+            if (!$this->Update()) {
+                $this->SendDebug("Update", "Initiale Datenabfrage fehlgeschlagen", 0);
+            }
         }
     }
 
@@ -107,7 +109,7 @@ class HWMonitor extends IPSModule
         } catch (Exception $e) {
             $this->SendDebug("Fehler", $e->getMessage(), 0);
             $this->LogMessage($e->getMessage(), KL_ERROR);
-            return;
+            return false;
         }
 
         $this->SendDebug("Verbindungseinstellung", "{$this->ReadPropertyString('IPAddress')} : {$this->ReadPropertyInteger('Port')}", 0);
@@ -132,6 +134,8 @@ class HWMonitor extends IPSModule
 
         // Löschen nicht mehr benötigter Variablen
         $this->deleteUnusedVariables($existingVariableIDs);
+
+        return true;
     }
 
     // Neue Methode zur Erstellung und Aktualisierung der Variablen


### PR DESCRIPTION
## Summary
- return `false` from `Update()` when JSON cannot be parsed
- check the result in `ApplyChanges()`
- document the boolean return value in README

## Testing
- `php -l "HW-Monitor/HW Monitor/module.php"` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ea50892f88326a336549b7ec728b9