### PR TITLE
Clean trailing whitespace in form.json

### DIFF
--- a/HW Monitor/form.json
+++ b/HW Monitor/form.json
@@ -1,10 +1,10 @@
 {
-    "elements": 
+    "elements":
     [
       {
         "type": "ExpansionPanel",
         "caption": "Info zum Modul",
-        "items": 
+        "items":
         [
           {
             "type": "Label",
@@ -46,14 +46,14 @@
           "column": "id",
           "direction": "ascending"
       },
-        "columns": 
+        "columns":
         [
             {
                 "name": "id",
                 "caption": "ID des Wertes",
                 "width": "150",
                 "add": 0,
-                "edit": 
+                "edit":
                 {
                     "type": "NumberSpinner"
                 }
@@ -66,7 +66,7 @@
     },
     {
       "type": "RowLayout",
-      "items": 
+      "items":
       [
         {
           "type": "Image",
@@ -81,4 +81,3 @@
     }
   ]
 }
-  


### PR DESCRIPTION
## Summary
- remove whitespace at line ends in `form.json`

## Testing
- `grep -n "[[:space:]]$" -n 'HW Monitor/form.json'`

------
https://chatgpt.com/codex/tasks/task_e_684ea50998608326b24993cdc43f4142