### PR TITLE
Handle JSON decoding failure

### DIFF
--- a/HW Monitor/README.md
+++ b/HW Monitor/README.md
@@ -78,12 +78,16 @@ Anzeige der gewünschten Variabeln oder Grafiken in der Visualisierung.
 ### 7. PHP-Befehlsreferenz
 
 `boolean HW_Update(integer $InstanzID);`
-Aktualisierung der Daten.
+Aktualisierung der Daten. Gibt bei erfolgreichem Einlesen der JSON-Daten `true`
+zurück, andernfalls `false`.
 
 Beispiel:
 `HW_Update(12345);`
 
 ### 8. Versionen
+
+Version 1.9 (15.06.2025)
+* Variablen bleiben erhalten, wenn keine Daten vom Hardware Monitor verfügbar sind.
 
 Version 1.8 (22.12.2024)
 * Anpassung Modulname


### PR DESCRIPTION
## Summary
- return `false` from `Update()` when JSON cannot be parsed
- check the result in `ApplyChanges()`
- document the boolean return value in README
- preserve variables when no data is available

## Testing
- `php -l "HW Monitor/module.php"` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ea50892f88326a336549b7ec728b9